### PR TITLE
camera: Fix labels of 0.6 and 2.0 cameras

### DIFF
--- a/sparse/etc/dconf/db/vendor.d/jolla-camera-hw.txt
+++ b/sparse/etc/dconf/db/vendor.d/jolla-camera-hw.txt
@@ -1,2 +1,2 @@
 [apps/jolla-camera]
-backCameraLabels=["1.0", "2.0", "0.6"]
+backCameraLabels=["1.0", "0.6", "2.0"]


### PR DESCRIPTION
[camera] Fix labels of 0.6 and 2.0 cameras. JB#56687