### PR TITLE
dconf: Document experimental config defaults to experimental-configs.txt

### DIFF
--- a/sparse/etc/dconf/db/vendor.d/experimental-configs.txt
+++ b/sparse/etc/dconf/db/vendor.d/experimental-configs.txt
@@ -1,0 +1,4 @@
+# Experimental homescreen configuration flags
+# [desktop/sailfish/experimental]
+# quickAppToggleGesture=false
+# lockscreen_notification_count=4


### PR DESCRIPTION
[dconf] Document experimental config defaults to experimental-configs.txt. JB#57679

Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>